### PR TITLE
Update screen decoupling branch: keep only backend-agnostic screen changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,6 @@ SDL_OBJ = \
     $(OBJ_DIR)/event_render.o \
     $(OBJ_DIR)/event.o \
     $(OBJ_DIR)/welcome.o \
-    $(OBJ_DIR)/screen.o \
     $(OBJ_DIR)/font.o
 endif
 
@@ -179,6 +178,7 @@ CARD_GAME_EXEC = card_game
 
 OBJS = \
     $(OBJ_DIR)/card_game.o \
+    $(OBJ_DIR)/screen.o \
     $(SDL_OBJ) \
     $(RAYLIB_OBJ) \
     $(OBJ_DIR)/sys_interface.o \

--- a/include/screen.h
+++ b/include/screen.h
@@ -9,7 +9,6 @@
 #ifndef _SCREEN_H_
 #define _SCREEN_H_
 
-#ifdef USE_SDL2
 
 #ifdef __cplusplus
 extern "C" {
@@ -115,7 +114,6 @@ int bInsertItemInElement(int iElmId, PSTRUCT_SCREEN_ITEM pstItem);
 }
 #endif
 
-#endif
 
 #endif
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -6,8 +6,6 @@
  * Description: Screen module
  */
 
-#ifdef USE_SDL2
-
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
@@ -398,6 +396,3 @@ int bInsertItemInElement(int iElmId, PSTRUCT_SCREEN_ITEM pstItem) {
   pstElement->astItem[pstElement->iCtItems] = *pstItem;
   return TRUE;
 }
-
-#endif
-


### PR DESCRIPTION
### Motivation
- Make the `screen` module usable by non-SDL backends by removing SDL-specific compile guards so the parsing/layout API is always available.
- Keep `screen.*` free of SDL/Raylib types so the header can be included in builds without SDL2.
- Ensure builds that enable only Raylib still compile and link the screen module.

### Description
- Removed `#ifdef USE_SDL2` / `#endif` wrapping the public declarations in `include/screen.h` so the header is always exposed while keeping only backend-agnostic types and signatures.
- Removed `#ifdef USE_SDL2` / `#endif` wrapping `src/screen.c` so the implementation is compiled regardless of backend selection and remains free of SDL/Raylib-specific types.
- Updated `Makefile` to include `$(OBJ_DIR)/screen.o` in `OBJS` (built unconditionally) instead of under `SDL_OBJ` so Raylib-only builds link the screen module.
- Reverted unrelated modifications to `src/card_game.c` so the branch scope matches the screen decoupling task.

### Testing
- Ran a full build with `make clean && make -j2`, which completed successfully.
- Compiled `src/screen.c` for Raylib-only with `make clean && make directories && make obj/screen.o USE_RAYLIB=1`, which succeeded.
- Compiled `src/screen.c` for SDL2 with `make clean && make directories && make obj/screen.o USE_SDL2=1`, which succeeded.

------