### PR TITLE
Docs: Update CONTRIBUTING, ENVIRONMENT and README for multi-frontend builds and workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,34 @@
 # 🤝 Guia de Contribuição
 
-Obrigado por querer contribuir com o **CCG – Console Card Game**!  
-Aqui estão algumas orientações rápidas para mantermos o projeto organizado.
+Obrigado por contribuir com o **CCG**.
+
+Este repositório está em transição para arquitetura **multi-frontend**. Hoje coexistem:
+- lógica de jogo/core
+- frontends Terminal, SDL2 e raylib
+- partes legadas e partes já migradas para API de frontend unificada
+
+O objetivo das contribuições é evoluir o projeto sem regressões entre backends.
 
 ---
 
 ## 🚀 Fluxo de contribuição
-1. Crie um fork do repositório
+
+1. Faça um fork do repositório
 2. Crie um branch descritivo:
    ```bash
    git checkout -b feature/minha-feature
    ```
 3. Implemente sua alteração
-4. Confirme que o projeto compila com `make`
-5. Abra um Pull Request relacionando a issue (se houver)
+4. Compile e valide o(s) backend(s) impactado(s)
+5. Abra um Pull Request com contexto técnico claro
 
 ---
 
-## � Padrão de Commits (Conventional Commits)
-Utilizamos o padrão [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) para mensagens de commit:
+## 🧾 Padrão de commits (Conventional Commits)
 
-```
+Utilizamos [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```text
 <tipo>[escopo opcional]: <descrição>
 
 [corpo opcional]
@@ -28,55 +36,123 @@ Utilizamos o padrão [Conventional Commits](https://www.conventionalcommits.org/
 [rodapé(s) opcional(is)]
 ```
 
-### Tipos de commit:
-- `feat`: Nova funcionalidade
-- `fix`: Correção de bug
-- `docs`: Mudanças na documentação
-- `style`: Formatação, ponto e vírgula ausente, etc (sem mudança de código)
-- `refactor`: Refatoração de código (sem nova feature ou correção)
-- `perf`: Melhoria de performance
-- `test`: Adição ou correção de testes
-- `build`: Mudanças no sistema de build ou dependências
-- `ci`: Mudanças nos arquivos de CI
-- `chore`: Outras mudanças que não modificam src ou test
+### Tipos
+- `feat`: nova funcionalidade
+- `fix`: correção de bug
+- `docs`: documentação
+- `style`: formatação (sem mudança de comportamento)
+- `refactor`: refatoração sem nova feature/fix
+- `perf`: melhoria de performance
+- `test`: testes
+- `build`: build/dependências
+- `ci`: integração contínua
+- `chore`: manutenção geral
 
-### Exemplos:
+### Exemplos
 ```bash
-feat: adicionar sistema de batalha
-fix: corrigir cálculo de dano das cartas
-docs: atualizar README com instruções de instalação
-feat!: mudar estrutura da API (BREAKING CHANGE)
+feat(frontend-raylib): adicionar mapeamento de evento de teclado
+fix(core): corrigir cálculo de dano crítico
+docs(readme): atualizar seção de backends e migração
+feat!: alterar contrato da API de frontend
 ```
 
-**Importante**: Commits que quebram compatibilidade devem usar `!` após o tipo ou incluir `BREAKING CHANGE:` no rodapé.
+Use `!` ou `BREAKING CHANGE:` quando houver quebra de compatibilidade.
 
 ---
 
-## �📏 Padrões de código
+## 🧱 Diretrizes de arquitetura para PRs
+
+### 1) Separe core de frontend
+
+- Evite acoplar regra de negócio ao backend gráfico.
+- Código de gameplay deve permanecer no core sempre que possível.
+- Rendering/input/backend-specific deve ficar isolado em módulos de frontend.
+
+### 2) Não quebre outros backends
+
+Ao alterar qualquer parte de execução, valide impactos em:
+- Terminal
+- SDL2
+- raylib
+
+Se a mudança for específica de backend, deixe explícito no PR e no commit scope.
+
+### 3) Respeite o estado de maturidade dos backends
+
+- **SDL2**: implementação funcional mais completa hoje.
+- **raylib**: backend em evolução (MVP), ainda em convergência.
+- **Terminal**: permanece funcional e relevante para baseline/debug.
+
+### 4) Migração para API unificada
+
+A migração para modelo de frontend unificado está em andamento.
+Contribuições são bem-vindas para reduzir dependência de loops legados,
+mas sem quebrar o comportamento atual.
+
+---
+
+## 🧪 Validação mínima antes do PR
+
+Execute ao menos os builds relacionados ao que foi alterado.
+
+### Linux
+```bash
+# terminal
+make LINUX=1 all
+
+# SDL2
+make LINUX=1 USE_SDL2=1 all
+
+# raylib
+make LINUX=1 USE_RAYLIB=1 all
+```
+
+### Win32 (MinGW)
+```bash
+# terminal
+make _WIN32=1 all
+
+# SDL2
+make _WIN32=1 USE_SDL2=1 all
+
+# raylib
+make _WIN32=1 USE_RAYLIB=1 all
+```
+
+### Perfis adicionais
+```bash
+make LINUX=1 DEBUG=1 all
+make LINUX=1 FAKE=1 all
+```
+
+Se não conseguir validar algum backend por limitação de ambiente, documente isso no PR.
+
+---
+
+## 🧹 Padrões de código
+
 - Linguagem: **C99**
 - Indentação: **2 espaços**
-- Variáveis declaradas no **início do escopo**
-- Notação húngara:
-  - `iVariavel` → int  
-  - `dVariavel` → double  
-  - `szTexto` → string estática  
-  - `pszTexto` → ponteiro para string  
-  - `stEstrutura` → struct  
-  - `pstEstrutura` → ponteiro para struct
-  - `a+variavel` -> array de tipo de variavel. Ex.: aszStringLst -> char *szString[]
-  - `g+variavel` -> global
-- Seguir boas práticas de modularização: headers em `include/`, código em `src/`
+- Variáveis declaradas no início do escopo
+- Convenções de nomenclatura históricas do projeto devem ser preservadas
+- Headers em `include/`, implementação em `src/`
+- Configuração runtime em `conf/*.xml` (não `config/`)
 
 ---
 
-## ✅ Checklist para Pull Requests
-- [ ] Código compila e roda (`make` sem erros)
-- [ ] Alterações testadas manualmente
-- [ ] Código segue padrão do projeto
-- [ ] Mensagem de commit segue o padrão Conventional Commits
-- [ ] Comentários/documentação atualizados
+## ✅ Checklist para Pull Request
+
+- [ ] Código compila no(s) backend(s) impactado(s)
+- [ ] Não houve regressão clara em backend não alterado
+- [ ] Escopo da mudança está claro (core, SDL2, raylib, terminal)
+- [ ] Commit(s) seguem Conventional Commits
+- [ ] Documentação atualizada quando necessário
 
 ---
 
-## 📬 Dúvidas?
-Abra uma [Discussion](https://github.com/SEU_USUARIO/CCG/discussions) ou crie uma issue.
+## 📬 Dúvidas
+
+Abra uma issue ou discussion descrevendo:
+- cenário
+- backend/plataforma
+- passos para reproduzir

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,7 +1,12 @@
-# ⚙️ Environment Setup – CCG (Console Card Game)
+# ⚙️ Environment Setup – CCG (Card Game Engine Multi-Frontend)
 
-Este guia mostra como preparar o ambiente para compilar e rodar o **CCG**  
+Este guia mostra como preparar o ambiente para compilar e rodar o **CCG**
 em **Linux** e **Windows (MinGW/Cygwin/MSYS2)** usando `make`.
+
+Atualmente, o projeto possui builds com foco em três modos:
+- Terminal (padrão)
+- SDL2 (`USE_SDL2=1`)
+- raylib (`USE_RAYLIB=1`)
 
 ---
 
@@ -12,37 +17,63 @@ em **Linux** e **Windows (MinGW/Cygwin/MSYS2)** usando `make`.
 ```bash
 # Debian/Ubuntu
 sudo apt update
-sudo apt install build-essential gcc make
+sudo apt install build-essential gcc make libxml2-dev
 
 # Fedora
 sudo dnf groupinstall "Development Tools"
+sudo dnf install libxml2-devel
 
 # Arch
-sudo pacman -S base-devel
+sudo pacman -S base-devel libxml2
 ```
 
-### 2. Clonar e compilar
+### 2. Dependências opcionais por backend
+
+```bash
+# SDL2 (Debian/Ubuntu)
+sudo apt install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev
+
+# raylib (Debian/Ubuntu; pacote pode variar por distro)
+sudo apt install libraylib-dev
+```
+
+> Observação: nomes de pacotes podem variar por distribuição.
+
+### 3. Clonar e compilar
 
 ```bash
 git clone https://github.com/repiazza/CCG.git
 cd CCG
-make LINUX=1
+
+# Terminal (padrão)
+make LINUX=1 all
 ./bin/card_game
 ```
 
-### 3. Opções extras
+### 4. Builds por backend
 
-- Compilação com debug:
+```bash
+# SDL2
+make LINUX=1 USE_SDL2=1 all
+./bin/card_game --sdl
 
-  ```bash
-  make DEBUG=1
-  ```
+# raylib
+make LINUX=1 USE_RAYLIB=1 all
+./bin/card_game --raylib
+```
 
-- Limpar artefatos:
+### 5. Opções extras
 
-  ```bash
-  make clean
-  ```
+```bash
+# Debug
+make LINUX=1 DEBUG=1 all
+
+# Fake
+make LINUX=1 FAKE=1 all
+
+# Limpeza
+make clean
+```
 
 ---
 
@@ -52,13 +83,24 @@ make LINUX=1
 
 Baixe e instale [MSYS2](https://www.msys2.org/).
 
-### 2. Instalar toolchain MinGW
+### 2. Instalar toolchain e libs
 
 Abra o terminal **MSYS2 MinGW64** e execute:
 
 ```bash
 pacman -Syu
 pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+pacman -S --needed mingw-w64-x86_64-libxml2
+```
+
+Dependências opcionais por backend:
+
+```bash
+# SDL2
+pacman -S --needed mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_image
+
+# raylib
+pacman -S --needed mingw-w64-x86_64-raylib
 ```
 
 ### 3. Clonar e compilar
@@ -66,32 +108,75 @@ pacman -S --needed base-devel mingw-w64-x86_64-toolchain
 ```bash
 git clone https://github.com/repiazza/CCG.git
 cd CCG
-make
+
+# Terminal (padrão)
+make _WIN32=1 all
 ./bin/card_game.exe
 ```
 
-### 4. Observações
+### 4. Builds por backend
 
-- O Makefile já detecta **mingw32/cygwin** via `gcc -dumpmachine`
-- Variáveis auxiliares no Makefile:
-  - `_WIN32` → ativa flags `-D_WIN32`
-  - `LINUX` → ativa flags `-DLINUX` e rpath
-- `mkdir` e `rm` são resolvidos automaticamente no MSYS2.
+```bash
+# SDL2
+make _WIN32=1 USE_SDL2=1 all
+./bin/card_game.exe --sdl
+
+# raylib
+make _WIN32=1 USE_RAYLIB=1 all
+./bin/card_game.exe --raylib
+```
+
+### 5. Observações
+
+- O Makefile detecta `mingw32/cygwin` via `gcc -dumpmachine`.
+- Use **MinGW64** para build/execução, não o shell MSYS puro.
+- `--sdl` e `--raylib` são mutuamente exclusivos em runtime.
+- Se um backend não foi compilado no binário, a seleção via CLI falha com mensagem de erro.
 
 ---
 
-## 📌 Dicas úteis
+## 🍎 Apple (macOS)
 
-- Sempre execute `make clean` ou `make all` antes de builds grandes.
-- Use `make -j$(nproc)` para compilar em paralelo (Linux).
-- Para Windows, compile **no terminal MinGW64**, não no MSYS2 padrão.
-- Caso queira instalar em pasta fixa, ajuste a variável `PREFIX` no `Makefile`.
-- O diretorio scripts contem rotinas automaticas para compilacao all ou so de fontes recém alterados.
+Exemplo base com Homebrew:
+
+```bash
+brew install gcc make libxml2 sdl2 sdl2_ttf sdl2_image raylib
+
+# Terminal
+make APPLE=1 all
+
+# SDL2
+make APPLE=1 USE_SDL2=1 all
+
+# raylib
+make APPLE=1 USE_RAYLIB=1 all
+```
+
+> No estado atual, flags/bibliotecas de raylib no macOS/Win32 podem exigir ajustes adicionais no ambiente.
+
+---
+
+## 📜 Scripts de build
+
+A pasta `scripts/` contém atalhos para build por plataforma e perfil:
+
+- `mkall_linux.sh`, `mkall_win32.sh`, `mkall_apple.sh`
+- variantes SDL (`mkallS_*`), raylib (`mkallR_*` em Win32), debug (`mkd*`), fake (`mkf*`), debug+fake (`mkfd*`)
+
+Exemplos:
+
+```bash
+./scripts/mkall_linux.sh
+./scripts/mkallS_linux.sh
+./scripts/mkallR_win32.sh
+```
 
 ---
 
 ## ✅ Resumo
 
-- **Linux:** `apt install build-essential` → `make`
-- **Windows:** instalar **MSYS2 + MinGW** → `make`
-- Binários ficam em `bin/card_game` (Linux) ou `bin/card_game.exe` (Windows).
+- **Terminal:** build padrão (sem `USE_*`)
+- **SDL2:** build com `USE_SDL2=1`
+- **raylib:** build com `USE_RAYLIB=1`
+- Configurações de runtime em XML dentro de `conf/`
+- Portabilidade operacional via Makefile + scripts de `scripts/`

--- a/README.md
+++ b/README.md
@@ -1,121 +1,205 @@
-# 🃏 CCG – Console Card Game
+# 🃏 CCG – Card Game Engine (C) com Multi-Frontend
 
-Um jogo de cartas colecionáveis **em C (ANSI/C89/C99)**, rodando direto no **terminal**.  
-O projeto é pensado para ser **leve, didático e open source**, servindo tanto como jogo quanto como exemplo de arquitetura em C.
+Projeto de jogo de cartas colecionáveis em **C (C89/C99)** em transição para uma arquitetura
+**multi-frontend**. O objetivo atual é manter o gameplay estável enquanto a camada de frontend
+é unificada entre **Terminal**, **SDL2** e **raylib**.
 
 ---
 
-## ✨ Features principais
+## 📌 Estado atual (source of truth)
 
-- Sistema de **jogadores** e **monstros**
-- **Decks** configuráveis
-- Mercado / loja para compra de cartas
-- Módulo de **batalha** entre jogadores
-- Interface via **terminal**
-- Estrutura modular (`src/` + `include/` + ... )
-- Makefile estruturado
-- Portabilidade Win32, Linux e Android
-- Rotina de debug simples e robusta (modulo trace -> log/card_game.log)
-- Rotina de historico de dialogo    (modulo trace -> log/card_game_dialog.log)
+- Seleção de backend em runtime via CLI:
+  - `--sdl`
+  - `--raylib`
+- Validação de conflito entre `--sdl` e `--raylib`
+- Três fluxos de execução existentes:
+  - **Terminal** (funcional, baseline/debug)
+  - **SDL2** (implementação mais completa no momento)
+  - **raylib** (MVP em evolução)
+- Build com Makefile para Linux / Win32 / Apple
+- Flags de build por backend:
+  - `USE_SDL2=1`
+  - `USE_RAYLIB=1`
+- Modos de build adicionais:
+  - `DEBUG=1`
+  - `FAKE=1`
+- Configuração em XML em `conf/` (ex.: `ccg.xml`, `screen.xml`, `msg.xml`, `image.xml`)
+- Scripts de compilação/portabilidade em `scripts/`
+
+---
+
+## 🧱 Arquitetura (legado + nova API)
+
+Hoje coexistem dois modelos:
+
+### 1) Modelo legado (predominante)
+
+Loops específicos por backend, ainda responsáveis por boa parte da execução principal:
+- `vSDL_MainLoop`
+- `vCNSL_MainLoop`
+
+### 2) Modelo novo (em evolução)
+
+API de frontend orientada a ciclo de frame/eventos, com funções no formato:
+- `init`
+- `pollEvent`
+- `beginFrame`
+- `endFrame`
+- `shouldQuit`
+- `shutdown`
+
+Situação atual:
+- **raylib** já opera nesse modelo novo (MVP)
+- **SDL2** e **Terminal** já inicializam via API, mas ainda preservam loops legados em partes do fluxo
+
+---
+
+## 🎯 Direção arquitetural
+
+- Convergir os frontends para um modelo unificado de eventos/frame
+- Preservar o gameplay/core isolado da camada de render/input
+- Manter **SDL2** como base funcional de referência durante a migração
+- Evoluir **raylib** como direção arquitetural de frontend
+- Manter **Terminal** como modo funcional e útil para debug/baseline
+
+> Importante: a migração para o modelo totalmente unificado **ainda não está concluída**.
+
+---
+
+## 🖥️ Backends e papéis atuais
+
+### Terminal
+- Continua funcional
+- Usado como baseline/debug
+- Mantém importância para testes rápidos e validação de fluxo
+
+### SDL2
+- Implementação mais completa atualmente
+- Contém fluxo de gameplay/render/UI mais maduro
+- Referência prática para comportamento do jogo durante a transição
+
+### raylib
+- Backend em estágio MVP
+- Já possui janela + loop + integração básica de eventos
+- Ainda não cobre todo o escopo funcional da versão SDL2
 
 ---
 
 ## 📂 Estrutura do projeto
 
-```
+```text
 ├── assets/           # imagens (.png)
-├── conf/             # xmls de configuracao (.xml)
-├── include/          # Cabeçalhos (.h)
-├── src/              # Implementações (.c)
-├── fonts/            # Fontes/texto (.ttf)
-├── scripts/          # scripts de compilação para prod/debug/fake (.sh)
-├── doc/              # documentacoes (.md)
-├── Makefile          # Build simplificado
+├── conf/             # XMLs de configuração
+├── include/          # cabeçalhos (.h)
+├── src/              # implementações (.c)
+├── fonts/            # fontes (.ttf)
+├── scripts/          # scripts de build/portabilidade
+├── doc/              # documentação
+├── Makefile          # build principal
 ├── .gitignore
 └── README.md
 ```
-## 📂 Diretorios temporários
 
-```
+Diretórios temporários de build/execução:
 
-├── build/            # arquivos de inclusao de makefile (.mk)
-├── obj/              # Arquivos objetos da compilacao (.o)
-├── log/              # Registros da execucao (.log)
-└── bin/              # Local onde o executavel sera gerado
-
+```text
+├── build/            # inclusão dinâmica de makefiles auxiliares
+├── obj/              # objetos (.o)
+├── log/              # logs
+└── bin/              # executáveis
 ```
 
 ---
 
 ## 🛠️ Como compilar
 
-Requisitos: GCC ou Clang + Make
+Requisitos: GCC ou Clang + Make.
+
+### Linux
 
 ```bash
-# Clonar o projeto
-git clone https://github.com/SEU_USUARIO/CCG.git
-cd CCG
+# Build padrão (terminal)
+make LINUX=1 all
 
-# Compilar
-Windows:
-./scripts/mk*_win32.sh
-   % Com SDL2
-   ./scripts/mk*S_win32.sh
-Linux:
-./scripts/mk*_linux.sh
-   % Com SDL2
-   ./scripts/mk*S_linux.sh
-Onde:
- * => all - Executa o Clean + criacao de diretorios ( usualmente o primeiro make do dia deve ser este )
- * => d - Debug flags de gdb
- * => (apenas mk_win32 ou mk_linux) - monta apenas os arquivos alterados desde a ultima compilacao
-# Executar
+# Build SDL2
+make LINUX=1 USE_SDL2=1 all
+
+# Build raylib
+make LINUX=1 USE_RAYLIB=1 all
+
+# Debug
+make LINUX=1 DEBUG=1 all
+
+# Fake
+make LINUX=1 FAKE=1 all
+```
+
+### Windows (MinGW/MSYS2)
+
+```bash
+# Build padrão (terminal)
+make _WIN32=1 all
+
+# Build SDL2
+make _WIN32=1 USE_SDL2=1 all
+
+# Build raylib
+make _WIN32=1 USE_RAYLIB=1 all
+```
+
+### Apple
+
+```bash
+# Build padrão (terminal)
+make APPLE=1 all
+
+# Build SDL2
+make APPLE=1 USE_SDL2=1 all
+
+# Build raylib
+make APPLE=1 USE_RAYLIB=1 all
+```
+
+Também é possível usar os atalhos de `scripts/` (ex.: `mkall_linux.sh`, `mkallS_linux.sh`, etc.).
+
+---
+
+## ▶️ Execução
+
+```bash
+# Padrão (terminal)
 ./bin/card_game
-   % Com SDL2
-   ./bin/card_game --sdl
+
+# Solicitar backend SDL2
+./bin/card_game --sdl
+
+# Solicitar backend raylib
+./bin/card_game --raylib
 ```
 
-Limpar artefatos:
+Notas:
+- `--sdl` e `--raylib` são mutuamente exclusivos.
+- Se um backend for solicitado sem ter sido compilado no binário atual,
+  o programa informa erro e encerra.
+
+---
+
+## 🧪 Testes e cobertura
 
 ```bash
-make clean
+make test
+make coverage
+make coverage-html
 ```
 
 ---
 
-## 🤝 Como contribuir
+## 🤝 Contribuição
 
-1. Faça um **fork** do repositório
-2. Crie um branch:
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md).
 
-   ```bash
-   git checkout -b feature/minha-feature
-   ```
-
-3. Commit suas mudanças seguindo o padrão [Conventional Commits](https://www.conventionalcommits.org/):
-
-   ```bash
-   git commit -m "feat: adicionar nova funcionalidade"
-   git commit -m "fix: corrigir bug no sistema de batalha"
-   ```
-
-4. Abra um **Pull Request** 🎉
-
-**Configure os Git hooks** para validação automática:
-
-```bash
-./scripts/setup-git-hooks.sh
-```
-
-Consulte o arquivo [CONTRIBUTING.md](CONTRIBUTING.md) para mais detalhes sobre padrões de commit e código.
-
----
-
-## 🗺️ Roadmap inicial
-
-- [x] Melhorar loop de batalha
-- [ ] Adicionar testes unitários
-- [ ] Suporte a diferentes modos de jogo
-- [ ] Localização (PT/EN)
-- [x] Suporte a SDL2 - **NOVO** - Em desenvolvimento
----
+Resumo rápido:
+- Use Conventional Commits
+- Evite acoplar core de jogo a backend específico
+- Ao alterar frontend, informe claramente o backend impactado
+- Não quebre fluxos de outros backends


### PR DESCRIPTION
### Motivation
- Document project transition to a multi-frontend architecture (Terminal, SDL2, raylib) and surface migration constraints.
- Make build and validation steps explicit per backend and platform to reduce regression risk across frontends.
- Provide clearer contribution and commit conventions to guide PRs that touch core vs frontend code.

### Description
- Overhauled `CONTRIBUTING.md` to introduce multi-frontend goals, `Conventional Commits` examples, architecture guidelines to separate core and frontend, backend validation checklist, and platform-specific build commands such as `make LINUX=1 USE_SDL2=1 all`.
- Reworked `ENVIRONMENT.md` to list per-backend dependencies and package names, add platform-specific install instructions (Linux, Win32/MSYS2, macOS), show build examples for `USE_SDL2` and `USE_RAYLIB`, and document helper scripts in `scripts/`.
- Expanded `README.md` to describe current state-of-truth (backend selection via CLI `--sdl`/`--raylib`), explain legacy vs new frontend API model, enumerate build profiles (`DEBUG`, `FAKE`, `USE_SDL2`, `USE_RAYLIB`), show run examples, and add references to `CONTRIBUTING.md` and `scripts/`.
- Standardized references to configuration path `conf/`, clarified temporary build directories (`build/`, `obj/`, `bin/`), and added test commands like `make test` and `make coverage` for consumers.

### Testing
- No automated tests were executed as part of this documentation-only change.