### PR TITLE
Docs: add ARCHITECTURE.md and overhaul CONTRIBUTING, ENVIRONMENT and README

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,127 @@
+# 🏗️ ARCHITECTURE – CCG
+
+## 🧠 Visão geral
+
+O CCG é uma engine de card game em **C (C89/C99)** com arquitetura **multi-frontend**.
+A direção técnica do projeto é desacoplar cada vez mais:
+
+- **core de jogo** (regras, entidades, fluxo)
+- **frontends** (input, render, loop de plataforma)
+
+Com isso, o mesmo core pode evoluir sem dependência rígida de um único backend gráfico.
+
+---
+
+## 🧩 API de frontend
+
+A base da arquitetura é a interface `STRUCT_FRONTEND_API`, usada para padronizar o ciclo de execução entre backends.
+
+Ciclo principal da API:
+
+- `init`
+- `pollEvent`
+- `beginFrame`
+- `endFrame`
+- `shouldQuit`
+- `shutdown`
+
+No estado atual, **SDL2**, **raylib** e **Terminal** implementam essa API em níveis diferentes de maturidade.
+
+---
+
+## 🧱 Estado atual dos backends
+
+- **SDL2**
+  - Backend mais completo no momento
+  - Implementação de referência funcional (gameplay + render/UI mais madura)
+
+- **raylib**
+  - Backend em estágio MVP
+  - Já usa o modelo novo de ciclo por eventos/frame
+  - Ainda não possui paridade funcional completa com SDL2
+
+- **Terminal**
+  - Continua funcional
+  - Útil para baseline/debug e validação rápida de fluxo
+
+---
+
+## ⚙️ Modelo de execução
+
+Atualmente coexistem dois modelos.
+
+### 1) Modelo legado (predominante)
+
+Loops específicos por backend:
+
+- `vSDL_MainLoop`
+- `vCNSL_MainLoop`
+
+Esse modelo ainda sustenta partes importantes da execução principal.
+
+### 2) Modelo novo (em evolução)
+
+Modelo baseado em `STRUCT_FRONTEND_API`, orientado a eventos/frame.
+
+- Já utilizado no backend raylib
+- Parcialmente adotado em SDL2/Terminal (inicialização e integração progressiva)
+
+---
+
+## 🎯 Direção arquitetural
+
+A migração em andamento segue os pontos abaixo:
+
+- convergência para um modelo unificado de frontend
+- remoção gradual dos loops legados
+- raylib como implementação alinhada ao modelo novo
+- SDL2 como base funcional durante a transição
+
+Importante: essa convergência ainda não está concluída.
+
+---
+
+## 🔧 Sistema de build
+
+- **Makefile** é a base de build do projeto
+- **scripts/** é a interface de uso recomendada para desenvolvimento diário
+- Há padronização por plataforma e perfil (Linux/Win32/Apple, debug/fake, backend)
+
+Exemplos de chaves de build no Makefile:
+
+- `USE_SDL2=1`
+- `USE_RAYLIB=1`
+- `DEBUG=1`
+- `FAKE=1`
+
+---
+
+## ⚙️ Configuração
+
+A configuração de runtime é feita por XML em `conf/`.
+
+Exemplos:
+
+- `conf/ccg.xml`
+- `conf/screen.xml`
+- `conf/msg.xml`
+- `conf/image.xml`
+
+Princípios atuais:
+
+- paths e parâmetros de execução configuráveis
+- separação entre configuração externa e código-fonte
+
+---
+
+## 🔁 CI/CD e versionamento
+
+O fluxo de versionamento segue **Conventional Commits**.
+
+Impacto semântico esperado dos tipos:
+
+- `feat` → incremento **minor**
+- `fix` → incremento **patch**
+- `BREAKING CHANGE` (ou `!`) → incremento **major**
+
+Esse padrão viabiliza versionamento/release automatizados em pipelines de CI/CD.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,34 @@
 # 🤝 Guia de Contribuição
 
-Obrigado por querer contribuir com o **CCG – Console Card Game**!  
-Aqui estão algumas orientações rápidas para mantermos o projeto organizado.
+Obrigado por contribuir com o **CCG**.
+
+Este repositório está em transição para arquitetura **multi-frontend**. Hoje coexistem:
+- lógica de jogo/core
+- frontends Terminal, SDL2 e raylib
+- partes legadas e partes já migradas para API de frontend unificada
+
+O objetivo das contribuições é evoluir o projeto sem regressões entre backends.
 
 ---
 
 ## 🚀 Fluxo de contribuição
-1. Crie um fork do repositório
+
+1. Faça um fork do repositório
 2. Crie um branch descritivo:
    ```bash
    git checkout -b feature/minha-feature
    ```
 3. Implemente sua alteração
-4. Confirme que o projeto compila com `make`
-5. Abra um Pull Request relacionando a issue (se houver)
+4. Compile e valide o(s) backend(s) impactado(s)
+5. Abra um Pull Request com contexto técnico claro
 
 ---
 
-## � Padrão de Commits (Conventional Commits)
-Utilizamos o padrão [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) para mensagens de commit:
+## 🧾 Padrão de commits (Conventional Commits)
 
-```
+Utilizamos [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```text
 <tipo>[escopo opcional]: <descrição>
 
 [corpo opcional]
@@ -28,55 +36,130 @@ Utilizamos o padrão [Conventional Commits](https://www.conventionalcommits.org/
 [rodapé(s) opcional(is)]
 ```
 
-### Tipos de commit:
-- `feat`: Nova funcionalidade
-- `fix`: Correção de bug
-- `docs`: Mudanças na documentação
-- `style`: Formatação, ponto e vírgula ausente, etc (sem mudança de código)
-- `refactor`: Refatoração de código (sem nova feature ou correção)
-- `perf`: Melhoria de performance
-- `test`: Adição ou correção de testes
-- `build`: Mudanças no sistema de build ou dependências
-- `ci`: Mudanças nos arquivos de CI
-- `chore`: Outras mudanças que não modificam src ou test
+### Tipos
+- `feat`: nova funcionalidade
+- `fix`: correção de bug
+- `docs`: documentação
+- `style`: formatação (sem mudança de comportamento)
+- `refactor`: refatoração sem nova feature/fix
+- `perf`: melhoria de performance
+- `test`: testes
+- `build`: build/dependências
+- `ci`: integração contínua
+- `chore`: manutenção geral
 
-### Exemplos:
+### Exemplos
 ```bash
-feat: adicionar sistema de batalha
-fix: corrigir cálculo de dano das cartas
-docs: atualizar README com instruções de instalação
-feat!: mudar estrutura da API (BREAKING CHANGE)
+feat(frontend-raylib): adicionar mapeamento de evento de teclado
+fix(core): corrigir cálculo de dano crítico
+docs(readme): atualizar seção de backends e migração
+feat!: alterar contrato da API de frontend
 ```
 
-**Importante**: Commits que quebram compatibilidade devem usar `!` após o tipo ou incluir `BREAKING CHANGE:` no rodapé.
+Use `!` ou `BREAKING CHANGE:` quando houver quebra de compatibilidade.
 
 ---
 
-## �📏 Padrões de código
+## 🧱 Diretrizes de arquitetura para PRs
+
+### 1) Separe core de frontend
+
+- Evite acoplar regra de negócio ao backend gráfico.
+- Código de gameplay deve permanecer no core sempre que possível.
+- Rendering/input/backend-specific deve ficar isolado em módulos de frontend.
+
+### 2) Não quebre outros backends
+
+Ao alterar qualquer parte de execução, valide impactos em:
+- Terminal
+- SDL2
+- raylib
+
+Se a mudança for específica de backend, deixe explícito no PR e no commit scope.
+
+### 3) Respeite o estado de maturidade dos backends
+
+- **SDL2**: implementação funcional mais completa hoje.
+- **raylib**: backend em evolução (MVP), ainda em convergência.
+- **Terminal**: permanece funcional e relevante para baseline/debug.
+
+### 4) Migração para API unificada
+
+A migração para modelo de frontend unificado está em andamento.
+Contribuições são bem-vindas para reduzir dependência de loops legados,
+mas sem quebrar o comportamento atual.
+
+---
+
+## 🧪 Validação mínima antes do PR
+
+Use scripts sempre que possível:
+
+```bash
+./scripts/mkall_linux.sh
+./scripts/mkallS_linux.sh
+```
+
+E execute ao menos os builds relacionados ao que foi alterado.
+
+### Linux
+```bash
+# terminal
+make LINUX=1 all
+
+# SDL2
+make LINUX=1 USE_SDL2=1 all
+
+# raylib
+make LINUX=1 USE_RAYLIB=1 all
+```
+
+### Win32 (MinGW)
+```bash
+# terminal
+make _WIN32=1 all
+
+# SDL2
+make _WIN32=1 USE_SDL2=1 all
+
+# raylib
+make _WIN32=1 USE_RAYLIB=1 all
+```
+
+### Perfis adicionais
+```bash
+make LINUX=1 DEBUG=1 all
+make LINUX=1 FAKE=1 all
+```
+
+Se não conseguir validar algum backend por limitação de ambiente, documente isso no PR.
+
+---
+
+## 🧹 Padrões de código
+
 - Linguagem: **C99**
 - Indentação: **2 espaços**
-- Variáveis declaradas no **início do escopo**
-- Notação húngara:
-  - `iVariavel` → int  
-  - `dVariavel` → double  
-  - `szTexto` → string estática  
-  - `pszTexto` → ponteiro para string  
-  - `stEstrutura` → struct  
-  - `pstEstrutura` → ponteiro para struct
-  - `a+variavel` -> array de tipo de variavel. Ex.: aszStringLst -> char *szString[]
-  - `g+variavel` -> global
-- Seguir boas práticas de modularização: headers em `include/`, código em `src/`
+- Variáveis declaradas no início do escopo
+- Convenções de nomenclatura históricas do projeto devem ser preservadas
+- Headers em `include/`, implementação em `src/`
+- Configuração runtime em `conf/*.xml` (não `config/`)
 
 ---
 
-## ✅ Checklist para Pull Requests
-- [ ] Código compila e roda (`make` sem erros)
-- [ ] Alterações testadas manualmente
-- [ ] Código segue padrão do projeto
-- [ ] Mensagem de commit segue o padrão Conventional Commits
-- [ ] Comentários/documentação atualizados
+## ✅ Checklist para Pull Request
+
+- [ ] Código compila no(s) backend(s) impactado(s)
+- [ ] Não houve regressão clara em backend não alterado
+- [ ] Escopo da mudança está claro (core, SDL2, raylib, terminal)
+- [ ] Commit(s) seguem Conventional Commits
+- [ ] Documentação atualizada quando necessário
 
 ---
 
-## 📬 Dúvidas?
-Abra uma [Discussion](https://github.com/SEU_USUARIO/CCG/discussions) ou crie uma issue.
+## 📬 Dúvidas
+
+Abra uma issue ou discussion descrevendo:
+- cenário
+- backend/plataforma
+- passos para reproduzir

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,97 +1,170 @@
-# ⚙️ Environment Setup – CCG (Console Card Game)
+# ⚙️ Environment Setup – CCG
 
-Este guia mostra como preparar o ambiente para compilar e rodar o **CCG**  
-em **Linux** e **Windows (MinGW/Cygwin/MSYS2)** usando `make`.
+Este guia mostra como preparar ambiente, compilar e executar o CCG em Linux, Windows (MSYS2/MinGW) e macOS.
 
 ---
 
-## 🐧 Linux (Debian/Ubuntu/Fedora/Arch)
+## 📜 Fluxo recomendado
 
-### 1. Instalar dependências básicas
+No dia a dia, use **scripts em `scripts/`** como interface principal de build.
+
+- `scripts/` = fluxo recomendado para dev
+- `Makefile` = base interna de compilação
+
+Padrão de nomes dos scripts:
+
+- `mk` → build incremental (sem `clean`)
+- `mkall` → build completo (`clean` + diretórios + build)
+- `S` → build com SDL2
+- `R` → build com raylib
+- `d` → debug
+- `f` → fake
+
+Exemplos reais:
+
+```bash
+./scripts/mkallS_linux.sh   # all + SDL2
+./scripts/mkdS_linux.sh      # incremental + debug + SDL2
+./scripts/mkall_linux.sh     # all terminal
+./scripts/mkallR_win32.sh    # all raylib (win32)
+```
+
+---
+
+## 🐧 Linux
+
+### 1) Dependências base
 
 ```bash
 # Debian/Ubuntu
 sudo apt update
-sudo apt install build-essential gcc make
+sudo apt install build-essential gcc make libxml2-dev
 
 # Fedora
 sudo dnf groupinstall "Development Tools"
+sudo dnf install libxml2-devel
 
 # Arch
-sudo pacman -S base-devel
+sudo pacman -S base-devel libxml2
 ```
 
-### 2. Clonar e compilar
+### 2) Dependências opcionais por backend
 
 ```bash
-git clone https://github.com/repiazza/CCG.git
-cd CCG
-make LINUX=1
-./bin/card_game
+# SDL2 (Debian/Ubuntu)
+sudo apt install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev
+
+# raylib (Debian/Ubuntu; pacote pode variar por distro)
+sudo apt install libraylib-dev
 ```
 
-### 3. Opções extras
+### 3) Build e execução (scripts)
 
-- Compilação com debug:
+```bash
+# terminal
+./scripts/mkall_linux.sh
+./bin/card_game
 
-  ```bash
-  make DEBUG=1
-  ```
+# SDL2
+./scripts/mkallS_linux.sh
+./bin/card_game --sdl
 
-- Limpar artefatos:
+# debug + SDL2
+./scripts/mkdallS_linux.sh
 
-  ```bash
-  make clean
-  ```
+# fake + terminal
+./scripts/mkfall_linux.sh
+```
+
+### 4) Build direto com make (base interna)
+
+```bash
+make LINUX=1 all
+make LINUX=1 USE_SDL2=1 all
+make LINUX=1 USE_RAYLIB=1 all
+make LINUX=1 DEBUG=1 all
+make LINUX=1 FAKE=1 all
+```
 
 ---
 
 ## 🪟 Windows (MSYS2/MinGW)
 
-### 1. Instalar MSYS2
+### 1) Instalar toolchain e libs
 
-Baixe e instale [MSYS2](https://www.msys2.org/).
-
-### 2. Instalar toolchain MinGW
-
-Abra o terminal **MSYS2 MinGW64** e execute:
+No terminal **MSYS2 MinGW64**:
 
 ```bash
 pacman -Syu
 pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+pacman -S --needed mingw-w64-x86_64-libxml2
+
+# SDL2
+pacman -S --needed mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_image
+
+# raylib
+pacman -S --needed mingw-w64-x86_64-raylib
 ```
 
-### 3. Clonar e compilar
+### 2) Build e execução (scripts)
 
 ```bash
-git clone https://github.com/repiazza/CCG.git
-cd CCG
-make
+# terminal
+./scripts/mkall_win32.sh
 ./bin/card_game.exe
+
+# SDL2
+./scripts/mkallS_win32.sh
+./bin/card_game.exe --sdl
+
+# raylib
+./scripts/mkallR_win32.sh
+./bin/card_game.exe --raylib
 ```
 
-### 4. Observações
+### 3) Build direto com make
 
-- O Makefile já detecta **mingw32/cygwin** via `gcc -dumpmachine`
-- Variáveis auxiliares no Makefile:
-  - `_WIN32` → ativa flags `-D_WIN32`
-  - `LINUX` → ativa flags `-DLINUX` e rpath
-- `mkdir` e `rm` são resolvidos automaticamente no MSYS2.
+```bash
+make _WIN32=1 all
+make _WIN32=1 USE_SDL2=1 all
+make _WIN32=1 USE_RAYLIB=1 all
+```
 
----
-
-## 📌 Dicas úteis
-
-- Sempre execute `make clean` ou `make all` antes de builds grandes.
-- Use `make -j$(nproc)` para compilar em paralelo (Linux).
-- Para Windows, compile **no terminal MinGW64**, não no MSYS2 padrão.
-- Caso queira instalar em pasta fixa, ajuste a variável `PREFIX` no `Makefile`.
-- O diretorio scripts contem rotinas automaticas para compilacao all ou so de fontes recém alterados.
+Observações:
+- Use shell **MinGW64** para compilar/rodar.
+- `--sdl` e `--raylib` são mutuamente exclusivos.
 
 ---
 
-## ✅ Resumo
+## 🍎 macOS
 
-- **Linux:** `apt install build-essential` → `make`
-- **Windows:** instalar **MSYS2 + MinGW** → `make`
-- Binários ficam em `bin/card_game` (Linux) ou `bin/card_game.exe` (Windows).
+Exemplo com Homebrew:
+
+```bash
+brew install gcc make libxml2 sdl2 sdl2_ttf sdl2_image raylib
+
+# terminal
+./scripts/mkall_apple.sh
+
+# SDL2
+./scripts/mkallS_apple.sh
+
+# build via make
+make APPLE=1 all
+make APPLE=1 USE_SDL2=1 all
+make APPLE=1 USE_RAYLIB=1 all
+```
+
+> No estado atual, raylib em macOS/Win32 pode exigir ajustes adicionais de ambiente.
+
+---
+
+## ✅ Resumo rápido
+
+- Prefira `scripts/` para build diário
+- `Makefile` é a base comum entre plataformas
+- Backends de build:
+  - terminal (padrão)
+  - SDL2 (`S` / `USE_SDL2=1`)
+  - raylib (`R` / `USE_RAYLIB=1`)
+- Configuração runtime em XML dentro de `conf/`

--- a/README.md
+++ b/README.md
@@ -1,121 +1,58 @@
-# 🃏 CCG – Console Card Game
+# 🃏 CCG – Card Game Engine em C
 
-Um jogo de cartas colecionáveis **em C (ANSI/C89/C99)**, rodando direto no **terminal**.  
-O projeto é pensado para ser **leve, didático e open source**, servindo tanto como jogo quanto como exemplo de arquitetura em C.
+CCG é um jogo/engine de cartas em **C (C89/C99)** com suporte a múltiplos frontends.
+O projeto busca ser **leve, didático e open source**, mantendo gameplay estável enquanto a camada gráfica evolui.
 
 ---
 
 ## ✨ Features principais
 
-- Sistema de **jogadores** e **monstros**
-- **Decks** configuráveis
-- Mercado / loja para compra de cartas
-- Módulo de **batalha** entre jogadores
-- Interface via **terminal**
-- Estrutura modular (`src/` + `include/` + ... )
-- Makefile estruturado
-- Portabilidade Win32, Linux e Android
-- Rotina de debug simples e robusta (modulo trace -> log/card_game.log)
-- Rotina de historico de dialogo    (modulo trace -> log/card_game_dialog.log)
+- Sistema de jogadores e monstros
+- Decks configuráveis
+- Loja de cartas
+- Módulo de batalha
+- Modo terminal funcional
+- Backend gráfico em evolução (SDL2/raylib)
+- Configuração externa via XML (`conf/`)
 
 ---
 
-## 📂 Estrutura do projeto
+## ⚡ Quick start
 
-```
-├── assets/           # imagens (.png)
-├── conf/             # xmls de configuracao (.xml)
-├── include/          # Cabeçalhos (.h)
-├── src/              # Implementações (.c)
-├── fonts/            # Fontes/texto (.ttf)
-├── scripts/          # scripts de compilação para prod/debug/fake (.sh)
-├── doc/              # documentacoes (.md)
-├── Makefile          # Build simplificado
-├── .gitignore
-└── README.md
-```
-## 📂 Diretorios temporários
-
-```
-
-├── build/            # arquivos de inclusao de makefile (.mk)
-├── obj/              # Arquivos objetos da compilacao (.o)
-├── log/              # Registros da execucao (.log)
-└── bin/              # Local onde o executavel sera gerado
-
-```
-
----
-
-## 🛠️ Como compilar
-
-Requisitos: GCC ou Clang + Make
+Fluxo recomendado (Linux):
 
 ```bash
-# Clonar o projeto
-git clone https://github.com/SEU_USUARIO/CCG.git
-cd CCG
-
-# Compilar
-Windows:
-./scripts/mk*_win32.sh
-   % Com SDL2
-   ./scripts/mk*S_win32.sh
-Linux:
-./scripts/mk*_linux.sh
-   % Com SDL2
-   ./scripts/mk*S_linux.sh
-Onde:
- * => all - Executa o Clean + criacao de diretorios ( usualmente o primeiro make do dia deve ser este )
- * => d - Debug flags de gdb
- * => (apenas mk_win32 ou mk_linux) - monta apenas os arquivos alterados desde a ultima compilacao
-# Executar
+./scripts/mkall_linux.sh
 ./bin/card_game
-   % Com SDL2
-   ./bin/card_game --sdl
 ```
 
-Limpar artefatos:
+Para outros cenários de build, consulte `ENVIRONMENT.md`.
+
+---
+
+## 🖥️ Backends (resumo)
+
+- **Terminal** → baseline/debug funcional
+- **SDL2** → backend mais completo atualmente
+- **raylib** → backend MVP em evolução
+
+Seleção em runtime (quando compilado com o backend correspondente):
 
 ```bash
-make clean
+./bin/card_game --sdl
+./bin/card_game --raylib
 ```
 
 ---
 
-## 🤝 Como contribuir
+## 📚 Documentação
 
-1. Faça um **fork** do repositório
-2. Crie um branch:
-
-   ```bash
-   git checkout -b feature/minha-feature
-   ```
-
-3. Commit suas mudanças seguindo o padrão [Conventional Commits](https://www.conventionalcommits.org/):
-
-   ```bash
-   git commit -m "feat: adicionar nova funcionalidade"
-   git commit -m "fix: corrigir bug no sistema de batalha"
-   ```
-
-4. Abra um **Pull Request** 🎉
-
-**Configure os Git hooks** para validação automática:
-
-```bash
-./scripts/setup-git-hooks.sh
-```
-
-Consulte o arquivo [CONTRIBUTING.md](CONTRIBUTING.md) para mais detalhes sobre padrões de commit e código.
+- [ENVIRONMENT.md](ENVIRONMENT.md) – setup, dependências e build
+- [CONTRIBUTING.md](CONTRIBUTING.md) – fluxo de colaboração
+- [ARCHITECTURE.md](ARCHITECTURE.md) – arquitetura técnica detalhada
 
 ---
 
-## 🗺️ Roadmap inicial
+## 📦 CI/CD
 
-- [x] Melhorar loop de batalha
-- [ ] Adicionar testes unitários
-- [ ] Suporte a diferentes modos de jogo
-- [ ] Localização (PT/EN)
-- [x] Suporte a SDL2 - **NOVO** - Em desenvolvimento
----
+Versionamento automatizado baseado em **Conventional Commits**.


### PR DESCRIPTION
### Motivation
- Document the project's shift to a multi-frontend architecture and clarify the intended separation between core and frontends.
- Provide clear contributor guidelines and standardized `Conventional Commits` usage to support automated versioning and safer changes across backends.
- Simplify and centralize build/run instructions and recommended developer scripts (`scripts/`) for Linux, Windows and macOS.

### Description
- Add `ARCHITECTURE.md` describing the multi-frontend design, the `STRUCT_FRONTEND_API` lifecycle, backend status (SDL2, raylib, Terminal) and migration direction.
- Rewrite `CONTRIBUTING.md` to include updated contribution flow, `Conventional Commits` examples, architecture guidelines for PRs, a checklist, and required build/validation commands such as `./scripts/mkall_linux.sh` and `make LINUX=1 USE_SDL2=1 all`.
- Expand `ENVIRONMENT.md` with recommended `scripts/` usage, detailed dependency and build steps per platform (Linux, Windows/MSYS2, macOS), and examples of `make` and script commands for different backends.
- Update `README.md` to reflect the multi-backend focus, provide a short quick-start (`./scripts/mkall_linux.sh`), summarize available backends, and link to the new docs (`ENVIRONMENT.md`, `CONTRIBUTING.md`, `ARCHITECTURE.md`).

### Testing
- No automated tests were modified or added as this is a documentation-only change. 
- No CI or automated test jobs were executed as part of this PR. 
- Local verification consisted of reviewing the added and updated markdown files for clarity and consistency, with no compilation or runtime checks performed.
